### PR TITLE
fix: use recent Keycloak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 **/*.secret
 certs
 **/*.bkp
-postgres_data
 pm2/node_modules
 **/__pycache__
 keycloak_backend/*.env

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 Keycloak install and backend API to manage groups CRUD in Keycloak
 
 ## Machine preparation
-- Install `docker` using this [guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-22-04). Don't forget to enable the docker service using `sudo systemctl enable docker`.
+
+Install `docker` using this [guide](https://docs.docker.com/engine/install/ubuntu/). Don't forget to enable the docker service using `sudo systemctl enable docker`.
 
 ## Keycloak Install
 
 - Copy the `.env.template` to `.env`
 - Copy the Keycloak backend environment template file with `cp keycloak_backend/keycloak_backend.env.template keycloak_backend/keycloak_backend.env` and modify the `BACKEND_DOMAIN` variable to the domain on which the Keycloak backend is will be hosted.
 
-- `docker compose up -d`
+- `docker compose up --wait`
 
 ## Keycloak Backend Flask Application
 
@@ -82,21 +83,24 @@ This README provides a basic overview of the application's functionality and usa
 
 ## Keycloak Toolbox
 
-:warning: This toolbox in a work in progress :warning: 
+:warning: This toolbox in a work in progress :warning:
 
-In order to facilitate realm deployment you can use the keycloak_toolbox.py file :
+In order to facilitate realm deployment you can use the `keycloak_toolbox.py` file :
 
 - Copy the template file
+
 ```bash
 cp new_realm_data.yaml.template new_realm_data.yaml
-```    
+```
 
 - Update the values inside the yaml according to your installation
 
 - Run the function to setup your keycloak
+
 ```python
 python3 keycloak_toolbox.py -r new_realm_data.yaml
-```    
+```
+
 ## Acknowledgement
 
 This research was supported by the EBRAINS research infrastructure, funded from the European Union’s Horizon 2020 Framework Programme for Research and Innovation under the Specific Grant Agreement No. 945539 (Human Brain Project SGA3).

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -6,19 +6,20 @@ encode gzip zstd
 
 redir /api /api/
 route /api/* {
-	uri strip_prefix /api
-	reverse_proxy localhost:8060 {
-		# health_uri /ok
-		# health_interval 10s
+    uri strip_prefix /api
+    reverse_proxy localhost:8060 {
+        # health_uri /ok
+        # health_interval 10s
 
-		header_up Host {host}
-		header_up X-Real-IP {remote_host}
-	}
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+    }
 }
 
 route /* {
     reverse_proxy localhost:8080 {
-        health_uri /
+        health_port 9000
+        health_uri /health/live
         health_interval 10s
 
         header_up Host {host}
@@ -27,13 +28,13 @@ route /* {
 }
 
 route {
-	respond "404 nothing here" 404
+    respond "404 nothing here" 404
 }
 
 handle_errors {
-	@502 {
-		path /session/*
-		expression `{http.error.status_code} == 502`
-	}
-	respond @502 "404 nothing here" 404
+    @502 {
+        path /session/*
+        expression `{http.error.status_code} == 502`
+    }
+    respond @502 "404 nothing here" 404
 }

--- a/chuv-theme/login/theme.properties
+++ b/chuv-theme/login/theme.properties
@@ -1,5 +1,8 @@
 parent=base
-import=common/keycloak
+#import=common/keycloak
+
+# defaults to false since 24.0
+redirectToAdmin=true
 
 styles=css/login.css
 stylesCommon=web_modules/@patternfly/react-core/dist/styles/base.css web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/pficon/pficon.css

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,64 +1,70 @@
-version: '3'
-
 volumes:
   postgres_data:
-      driver: local
+    driver: local
 
 services:
   postgres:
-      image: postgres
-      environment:
-        POSTGRES_DB: keycloak
-        POSTGRES_USER: keycloak
-        POSTGRES_PASSWORD: ${DB_PASSWORD}
-        PGDATA: /var/lib/postgresql/data/pgdata
-      volumes:
-        - ./postgres_data:/var/lib/postgresql/data
-      restart: always
+    image: postgres:15.3
+    shm_size: 128mb
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   keycloak:
-      container_name: keycloak
-      image: quay.io/keycloak/keycloak:21.1.2
-      command: --spi-login-protocol-openid-connect-legacy-logout-redirect-uri=true start
-      # command: start-dev
-      environment:
-        KC_FEATURES:
-          authorization
-          token-exchange
-          docker
-          impersonation
-          scripts
-          upload-scripts
-          web-authn
-          client-policies
-          dynamic-scopes
-        KC_DB: postgres
-        KC_DB_URL_HOST: postgres
-        KC_DB_USERNAME: ${DB_USER}        
-        KC_DB_PASSWORD: ${DB_PASSWORD}
-        DB_DATABASE: keycloak
-        DB_SCHEMA: public
-        KEYCLOAK_USER: ${KEYCLOAK_USER}
-        KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}
-        KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
-        KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-        #when in start-dev mode
-        # KEYCLOAK_FRONTEND_URL: ${KEYCLOAK_HOSTNAME}
-        #try with cert keys
-        KC_HOSTNAME: ${KEYCLOAK_HOSTNAME}
-        KC_HOSTNAME_ADMIN: ${KEYCLOAK_HOSTNAME}
-        #INFORMATION for KC_PROXY: none is the supposed default value, but if not specified here we
-        #can not access the admin console. When using caddy use edge, it automatically 
-        #sets http.enabled=true and http.proxy-address-forwarding=true
-        KC_PROXY: 'edge'
-#        KC_HTTPS_CERTIFICATE_FILE: /etc/x509/https/tls.crt
-#        KC_HTTPS_CERTIFICATE_KEY_FILE: /etc/x509/https/tls.key
-      ports:
-        - 127.0.0.1:8080:8080
-        - 127.0.0.1:8443:8443
-      depends_on:
-        - postgres
-      volumes:
-#        - ./certs/fullchain.pem:/etc/x509/https/tls.crt
-#        - ./certs/privkey.pem:/etc/x509/https/tls.key
-        - ./chuv-theme:/opt/keycloak/themes/chuv-theme
-      restart: always
+    container_name: keycloak
+    image: quay.io/keycloak/keycloak:25.0
+    command: --spi-login-protocol-openid-connect-legacy-logout-redirect-uri=true start
+    # command: start-dev
+    environment:
+      KC_FEATURES: authorization:v1,token-exchange:v1,docker:v1,impersonation:v1,scripts:v1,web-authn:v1,client-policies:v1,dynamic-scopes:v1
+      KC_DB: postgres
+      KC_DB_USERNAME: ${DB_USER}
+      KC_DB_PASSWORD: ${DB_PASSWORD}
+      KC_DB_SCHEMA: public
+      KC_DB_URL_HOST: postgres
+      KC_DB_URL_DATABASE: keycloak
+      KEYCLOAK_USER: ${KEYCLOAK_USER}
+      KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      #when in start-dev mode
+      # KEYCLOAK_FRONTEND_URL: ${KEYCLOAK_HOSTNAME}
+      #try with cert keys
+      KC_HOSTNAME: https://${KEYCLOAK_HOSTNAME}/
+      KC_HOSTNAME_ADMIN: https://${KEYCLOAK_HOSTNAME}/
+      #INFORMATION for KC_PROXY: none is the supposed default value, but if not specified here we
+      #can not access the admin console. When using caddy use edge, it automatically
+      #sets http.enabled=true and http.proxy-address-forwarding=true
+      #KC_PROXY: "edge" # deprecated
+      KC_PROXY_HEADERS: "xforwarded"
+      KC_HTTP_ENABLED: "true"
+      #KC_HTTPS_CERTIFICATE_FILE: /etc/x509/https/tls.crt
+      #KC_HTTPS_CERTIFICATE_KEY_FILE: /etc/x509/https/tls.key
+      KC_HEALTH_ENABLED: 'true'
+    ports:
+      - 127.0.0.1:8080:8080
+      - 127.0.0.1:8443:8443
+      - 127.0.0.1:9000:9000
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      #        - ./certs/fullchain.pem:/etc/x509/https/tls.crt
+      #        - ./certs/privkey.pem:/etc/x509/https/tls.key
+      - ./chuv-theme:/opt/keycloak/themes/chuv-theme
+    restart: always
+    healthcheck: # https://github.com/keycloak/keycloak/issues/17273#issuecomment-1693549331
+      test: cat /proc/net/tcp6 | grep '00000000000000000000000000000000:1F90 00000000000000000000000000000000:0000' || exit 1
+      interval: 5s
+      timeout: 2s
+      retries: 20
+      start_period: 120s

--- a/keycloak_backend/api/hipcloak.py
+++ b/keycloak_backend/api/hipcloak.py
@@ -217,7 +217,7 @@ class Hipcloak:
         except Exception as e:
             print(f"Error retrieving members for group '{group_id}': {str(e)}")
             return None
-    
+
     def get_group_details_from_path(self, group_path):
         """
         Retrieve details of a group in the Keycloak realm by its path.
@@ -234,12 +234,12 @@ class Hipcloak:
             If the group does not exist, it prints a message and returns None.
         """
         try:
-            group_info = self._kc_admin.get_group_by_path(group_path)
-            if group_info:
-                return group_info
-            else:
+            group = self._kc_admin.get_group_by_path(group_path)
+            if not group:
                 print(f"Group not found at path '{group_path}'.")
-                return None
+                return
+
+            return self._kc_admin.get_group(group["id"])
         except Exception as e:
             print(f"Error retrieving group details from path '{group_path}': {str(e)}")
             return None

--- a/keycloak_backend/requirements.txt
+++ b/keycloak_backend/requirements.txt
@@ -1,5 +1,5 @@
 # gunicorn
-gunicorn
+gunicorn>=22.0,<23
 
 # requests
 requests
@@ -23,7 +23,7 @@ pyyaml
 gevent
 
 #python-keycloak
-python-keycloak
+python-keycloak>=4.2,<5
 
 #httpx
 httpx


### PR DESCRIPTION
I'm playing with this, Keycloak 21.1 is eol since July 2023. Also `postgres:latest` feels dangerous :)

DSDIP-523

Upgrade steps:

- Backup the postgres data
- Remove any existing (unused) volumes
- Mount the volume into postgres and copy the "local" data into it using `cp -rp`
- Replace the local data with the volume data check that things are ok
- Slowly bump Keycloak to each version: 22.0, 23.0, 24.0, 25.0
- Bump the requirements of keycloak backend `sudo pip install -U -r requirements.txt`
- Restart the gunicorn backend
- Party time!