### PR TITLE
chore: bump Keycloak to 25.0.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       retries: 5
   keycloak:
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:25.0
+    image: quay.io/keycloak/keycloak:25.0.5
     command: --spi-login-protocol-openid-connect-legacy-logout-redirect-uri=true start
     # command: start-dev
     environment:


### PR DESCRIPTION
it's probably safe as we're not using SAML.

https://www.keycloak.org/2024/09/keycloak-2505-released.html